### PR TITLE
Update generator for commotion-router v1.2 release

### DIFF
--- a/scripts/parse.pl
+++ b/scripts/parse.pl
@@ -39,7 +39,7 @@ use File::Next;
 use Text::Balanced qw(extract_bracketed extract_delimited extract_tagged);
 use DateTime;
 
-our $VERSION = 0.3.0;
+our $VERSION = 0.3.1;
 
 #**
 # @var verbosity Print debug messages

--- a/scripts/parse.pl
+++ b/scripts/parse.pl
@@ -71,14 +71,22 @@ my %repos = (
         'source' => 'https://github.com/opentechinstitute/commotion-feed.git',
         'branch' => 'master',
     },
+    'commotion-dnsproxy' => {
+        'source' => 'https://github.com/opentechinstitute/commotion-dnsproxy.git',
+        'branch' => 'master',
+    },
     'commotiond' => {
         'source' => 'https://github.com/opentechinstitute/commotiond.git',
         'branch' => 'master',
     },
     'commotion-service-manager' => {
         'source' =>
-          'https://github.com/opentechinstitute/commotion-service-manager.git',
+        'https://github.com/opentechinstitute/commotion-service-manager.git',
         'branch' => 'master',
+    },
+    'luci' => {
+        'source' => 'https://github.com/opentechinstitute/luci.git',
+        'branch' => 'master', 
     },
     'luci-commotion' => {
         'source' => 'https://github.com/opentechinstitute/luci-commotion.git',


### PR DESCRIPTION
Adds the following repos:
- commotion-dnsproxy - master branch
- oti's luci fork - master branch

No other functional changes.

To test:
1. Install perl prerequisites, cd to Scripts directory, and run parse.pl. Note that the script will throw warnings on the initial run (Issue #9), but should finish successfully.
2. Script should generate a PO file (in working/translations/) for each supported language. Each PO file should contain a listing for each translatable string. Any previously translated strings should be reused in the new PO file.
